### PR TITLE
Check released artifact at maven.org and then register release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: New features and enhancements
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+            bug
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-build.yml@v2.1.7
     with:
       java-version: "8"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.7
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/multichannelserver/XMLConfJoiner/_VER_/XMLConfJoiner-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -1,0 +1,15 @@
+name: Check for artifact and register release
+
+on:
+  workflow_run:
+    workflows: ["Maven Release"]
+    types:
+      - completed
+
+jobs:
+  build:
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@2.1.7
+    if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
+    with:
+      artifact-pattern: "octopus/multichannelserver/XMLConfJoiner/_VER_/XMLConfJoiner-_VER_.jar"
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-maven-release.yml@v2.1.7
     with:
       java-version: '8'
     secrets: inherit


### PR DESCRIPTION
- Check released artifact at maven.org
- Switch to octopus-base v2.1.7
- Release registration
- Changelog support